### PR TITLE
(#11) Fix return value for apt_update

### DIFF
--- a/agent/package.ddl
+++ b/agent/package.ddl
@@ -163,6 +163,10 @@ action "apt_update", :description => "Update the apt cache" do
            :description => "Output from apt-get",
            :display_as  => "Output"
 
+    output :outdated_packages,
+           :description => "Outdated packages",
+           :display_as  => "Outdated Packages"
+
     output :exitcode,
            :description => "The exitcode from the apt-get command",
            :display_as => "Exit Code"

--- a/agent/package.rb
+++ b/agent/package.rb
@@ -45,6 +45,7 @@ module MCollective
         result = package_helper.apt_update
         reply[:exitcode] = result[:exitcode]
         reply[:output] = result[:output]
+        reply[:outdated_packages] = result[:outdated_packages]
       end
 
       action 'checkupdates' do

--- a/spec/util/package/packagehelpers_spec.rb
+++ b/spec/util/package/packagehelpers_spec.rb
@@ -76,15 +76,17 @@ module MCollective
 
           it 'should perform the update' do
             File.expects(:exists?).with('/usr/bin/apt-get').returns(true)
+            File.expects(:exists?).with('/usr/bin/apt-get').returns(true)
             shell = mock
             status = mock
             shell.stubs(:runcommand)
             shell.stubs(:status).returns(status)
             status.stubs(:exitstatus).returns(0)
             Shell.expects(:new).with('/usr/bin/apt-get update', :stdout => "").returns(shell)
+            Shell.stubs(:new).with('/usr/bin/apt-get --simulate dist-upgrade', :stdout => "").returns(shell)
 
             result = PackageHelpers.apt_update
-            result.should == {:exitcode => 0, :output => ""}
+            result.should == {:exitcode => 0, :output => "", :outdated_packages => [], :package_manager => "apt"}
           end
 
         end

--- a/util/package/packagehelpers.rb
+++ b/util/package/packagehelpers.rb
@@ -107,7 +107,10 @@ module MCollective
           result[:exitcode] = cmd.status.exitstatus
 
           raise "apt-get update failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
-          return result
+
+          # Everything was fine.  Discard the current result and return the
+          # actual status of the system.
+          return apt_checkupdates
         end
 
         def self.packagemanager


### PR DESCRIPTION
On the agent side apt_update, update the packages information and
returns the status of this operation (success and failure), while the
application side expect a list of outdated packages to be provided.

This list of outdated packages is available using the apt_checkupdates
action of the agent.

Fix this issue by calling the apt_checkupdates method and return it's
value if the update succeeds.

Fixes #11