### PR TITLE
Add searching to see if package is available

### DIFF
--- a/agent/package.ddl
+++ b/agent/package.ddl
@@ -158,6 +158,25 @@ action "yum_clean", :description => "Clean the YUM cache" do
            :display_as => "Exit Code"
 end
 
+action "yum_isavailable", :description => "Report if a package is available to yum list" do
+    input :package,
+          :prompt      => "Package Name",
+          :description => "Package to retrieve information of, like mcollective-1.0",
+          :type        => :string,
+          :validation  => :shellsafe,
+          :optional    => false,
+          :maxlength   => 90
+
+    output :output,
+           :description => "Output from the package manager",
+           :display_as  => "Output"
+
+    output :exitcode,
+           :description => "The exitcode from the yum command",
+           :display_as  => "Exit Code"
+end
+
+
 action "apt_update", :description => "Update the apt cache" do
     output :output,
            :description => "Output from apt-get",

--- a/agent/package.rb
+++ b/agent/package.rb
@@ -41,6 +41,14 @@ module MCollective
         reply[:output] = result[:output]
       end
 
+      action 'yum_isavailable' do
+        package = request[:package]
+        version = request[:version]
+        result = package_helper.yum_isavailable(package, version)
+        reply[:exitcode] = result[:exitcode]
+        reply[:output] = result[:output]
+      end
+
       action 'apt_update' do
         result = package_helper.apt_update
         reply[:exitcode] = result[:exitcode]

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -36,7 +36,7 @@ module MCollective
 
           expect{
             @app.post_option_parser({})
-          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates'
+          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, count, md5, yum_clean, yum_checkupdates, yum_isavailable, apt_update, checkupdates, apt_checkupdates'
         end
 
         it 'should parse "action" "package" correctly' do

--- a/util/package/packagehelpers.rb
+++ b/util/package/packagehelpers.rb
@@ -97,6 +97,32 @@ module MCollective
           return result
         end
 
+        def self.yum_isavailable(package, version)
+          raise "Cannot find yum at /usr/bin/yum" unless File.exists?("/usr/bin/yum")
+          result = {:exitcode => nil,
+                    :output => ""}
+
+          if version.nil?
+            cmd = Shell.new(
+              "/usr/bin/yum list -q #{package}",
+              :stdout => result[:output]
+            )
+          else
+            # If we specify the version, but the package would be downgraded, the information
+            # won't show without passing in --showduplicates
+            cmd = Shell.new(
+              "/usr/bin/yum list -q --showduplicates #{package}-#{version}",
+              :stdout => result[:output]
+            )
+          end
+
+          cmd.runcommand
+          result[:exitcode] = cmd.status.exitstatus
+
+          raise "Error: No matching Packages to list" unless result[:exitcode] == 0
+          return result
+        end
+
         def self.apt_update
           raise 'Cannot find apt-get at /usr/bin/apt-get' unless File.exists?('/usr/bin/apt-get')
           result = {:exitcode => nil,


### PR DESCRIPTION
Adds a `yum_isavalable` function to test that yum can actually see
metadata for a combination of a package(and ideally, version) is
available to the node, before we start doing things like stopping
services and trying to do updates.