### PR TITLE
(#15) Add package search to for package availability

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,165 @@
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Exclude:
+    - "module/**/*"
+    - "vendor/**/*"
+    - "spec/fixtures/**/*"
+
+# restore pre 0.45 behaviour
+Style/SingleLineBlockParams:
+  Methods:
+    - reduce:
+        - a
+        - e
+    - inject:
+        - a
+        - e
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Lint/NonLocalExitFromIterator:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/WordArray:
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/RescueModifier:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Style/Documentation:
+  Severity: warning
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 180
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 50
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Security/MarshalLoad:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+# @todo use safe_load but its a big change
+Security/YAMLLoad:
+  Enabled: false
+
+Performance/RegexpMatch:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Lint/RescueWithoutErrorClass:
+  Enabled: false
+
+Performance/StringReplacement:
+  Enabled: false

--- a/agent/package.ddl
+++ b/agent/package.ddl
@@ -66,6 +66,31 @@ requires :mcollective => "2.2.1"
     end
 end
 
+action "search", :description => "Search package manager for package availability" do
+    display :always
+
+    input :package,
+          :prompt      => "Package Name",
+          :description => "Package to search for, either name, glob, or package spec",
+          :type        => :string,
+          :validation  => :shellsafe,
+          :optional    => false,
+          :maxlength   => 90
+
+    output :package_count,
+           :description => "Number of packages available",
+           :display_as  => "Number of Packages Available"
+
+    output :available_packages,
+           :description => "Available packages",
+           :display_as  => "Available Packages"
+
+    summarize do
+       aggregate summary(:package_count)
+    end
+
+end
+
 action "status", :description => "Get the status of a package" do
     display :always
 

--- a/agent/package.rb
+++ b/agent/package.rb
@@ -1,69 +1,73 @@
 module MCollective
   module Agent
-    class Package<RPC::Agent
+    class Package < RPC::Agent
 
-      action 'install' do
+      action "install" do
         Package.do_pkg_action(request[:package], :install, reply, request[:version])
       end
 
-      action 'update' do
+      action "update" do
         Package.do_pkg_action(request[:package], :update, reply)
       end
 
-      action 'uninstall' do
+      action "uninstall" do
         Package.do_pkg_action(request[:package], :uninstall, reply)
       end
 
-      action 'purge' do
+      action "purge" do
         Package.do_pkg_action(request[:package], :purge, reply)
       end
 
-      action 'status' do
+      action "status" do
         Package.do_pkg_action(request[:package], :status, reply)
       end
 
-      action 'count' do
+      action "search" do
+        Package.do_pkg_action(request[:package], :search, reply)
+      end
+
+      action "count" do
         result = package_helper.count
         reply[:exitcode] = result[:exitcode]
         reply[:output] = result[:output]
       end
 
-     action 'md5' do
+      action "md5" do
         result = package_helper.md5
         reply[:exitcode] = result[:exitcode]
         reply[:output] = result[:output]
       end
 
-      action 'yum_clean' do
-        clean_mode = request[:mode] || @config.pluginconf.fetch('package.yum_clean_mode', 'all')
+      action "yum_clean" do
+        clean_mode = request[:mode] || @config.pluginconf.fetch("package.yum_clean_mode", "all")
         result = package_helper.yum_clean(clean_mode)
         reply[:exitcode] = result[:exitcode]
         reply[:output] = result[:output]
       end
 
-      action 'apt_update' do
+      action "apt_update" do
         result = package_helper.apt_update
         reply[:exitcode] = result[:exitcode]
         reply[:output] = result[:output]
         reply[:outdated_packages] = result[:outdated_packages]
       end
 
-      action 'checkupdates' do
-        do_checkupdates_action('checkupdates')
+      action "checkupdates" do
+        do_checkupdates_action("checkupdates")
       end
 
-      action 'yum_checkupdates' do
-        do_checkupdates_action('yum_checkupdates')
+      action "yum_checkupdates" do
+        do_checkupdates_action("yum_checkupdates")
       end
 
-      action 'apt_checkupdates' do
-        do_checkupdates_action('apt_checkupdates')
+      action "apt_checkupdates" do
+        do_checkupdates_action("apt_checkupdates")
       end
 
       # Identifies the configured package provider
       # Defaults to puppet
       def self.package_provider
-        return Config.instance.pluginconf.fetch('package.provider', 'puppet')
+        Config.instance.pluginconf.fetch("package.provider", "puppet")
       end
 
       # Loads both the base class that all providers should inherit from,
@@ -74,7 +78,7 @@ module MCollective
         Log.debug("Loading %s package provider" % provider)
 
         begin
-          PluginManager.loadclass('MCollective::Util::Package::Base')
+          PluginManager.loadclass("MCollective::Util::Package::Base")
           PluginManager.loadclass("MCollective::Util::Package::#{provider}")
           Util::Package.const_get(provider)
         rescue => e
@@ -91,14 +95,14 @@ module MCollective
       #
       # which will then be returned as
       #
-      #   {:x => 'y'}
+      #   {:x => "y"}
       #
       def self.provider_options(provider, version = nil)
         provider_options = {}
 
         Config.instance.pluginconf.each do |k, v|
           if k =~ /package\.#{provider}/
-            provider_options[k.split('.').last.to_sym] = v
+            provider_options[k.split(".").last.to_sym] = v
           end
         end
 
@@ -117,13 +121,14 @@ module MCollective
         provider = Package.load_provider_class(Package.package_provider).new(package, Package.provider_options(Package.package_provider, version))
         result = provider.send(action)
 
+        # somewhere around here this is converting the hash to a string :\
         if action == :status
           result.each do |k,v|
-            reply[k] = v.to_s
+            reply[k] = v.is_a?(Array) || v.is_a?(Hash) ? v : v.to_s
           end
         else
           result[:status].each do |k,v|
-            reply[k] = v.to_s
+            reply[k] = v.is_a?(Array) || v.is_a?(Hash) ? v : v.to_s
           end
         end
 
@@ -133,6 +138,7 @@ module MCollective
       end
 
       private
+
       # Calls the correct helper method corresponding to the supplied
       # action and updates the agents reply values.
       def do_checkupdates_action(action)
@@ -145,8 +151,8 @@ module MCollective
 
       # Loads and returns the package_helper class
       def package_helper
-        PluginManager.loadclass('MCollective::Util::Package::PackageHelpers')
-        Util::Package.const_get('PackageHelpers')
+        PluginManager.loadclass("MCollective::Util::Package::PackageHelpers")
+        Util::Package.const_get("PackageHelpers")
       end
     end
   end

--- a/application/package.rb
+++ b/application/package.rb
@@ -1,9 +1,9 @@
 module MCollective
   class Application
-    class Package<MCollective::Application
+    class Package < MCollective::Application
       description "Install, uninstall, update, purge and perform other actions to packages"
 
-      usage <<-END_OF_USAGE
+      usage <<-USAGE
 mco package [OPTIONS] [FILTERS] <ACTION> <PACKAGE>
 Usage: mco package <PACKAGE> <install|uninstall|purge|update|status>
        mco package <count|md5>
@@ -17,13 +17,14 @@ The ACTION can be one of the following:
     status           - determine whether PACKAGE is installed and report its version
     count            - determine number of packages installed
     md5              - determine md5 of package list
+    search           - Determine if package is available to the system
     yum_clean        - clean the yum cache
     yum_checkupdates - display available updates from yum
     apt_update       - update all available packages
     apt_checkupdates - display available updates from apt
     checkupdates     - display available updates
 
-END_OF_USAGE
+USAGE
 
       option :yes,
              :arguments   => ["--yes", "-y"],
@@ -37,41 +38,58 @@ END_OF_USAGE
              :required    => false
 
       def handle_message(action, message, *args)
-        messages = {1 => 'Please specify package name and action',
-                    2 => "Action has to be one of %s",
-                    3 => "Do you really want to operate on packages unfiltered? (y/n): "}
+        messages = {
+          1 => "Please specify package name and action",
+          2 => "Action has to be one of %s",
+          3 => "Do you really want to operate on packages unfiltered? (y/n): "
+        }
         send(action, messages[message] % args)
       end
 
       def post_option_parser(configuration)
-        valid_global_actions = ['count', 'md5', 'yum_clean', 'yum_checkupdates', 'apt_update', 'checkupdates', 'apt_checkupdates']
-        if (ARGV.size < 2) and !valid_global_actions.include?(ARGV[0])
+        valid_global_actions = %w[
+          count
+          md5
+          yum_clean
+          yum_checkupdates
+          apt_update
+          checkupdates
+          apt_checkupdates
+        ]
+        if (ARGV.size < 2) && !valid_global_actions.include?(ARGV[0])
           handle_message(:raise, 1)
         else
 
-          valid_actions = ['install', 'uninstall', 'purge', 'update', 'status'].concat(valid_global_actions)
+          valid_actions = %w[
+            install
+            uninstall
+            purge
+            update
+            status
+            search
+          ].concat(valid_global_actions)
 
           if valid_actions.include?(ARGV[0])
             configuration[:action] = ARGV.shift
             unless valid_global_actions.include?(ARGV[0])
               configuration[:package] = ARGV.shift
-            end 
+            end
           elsif valid_actions.include?(ARGV[1])
             configuration[:package] = ARGV.shift
             configuration[:action] = ARGV.shift
           else
-            handle_message(:raise, 2, valid_actions.join(', '))
+            handle_message(:raise, 2, valid_actions.join(", "))
           end
         end
       end
 
       def validate_configuration(configuration)
-        unless [ 'status', 'count', 'md5'].include?(configuration[:action])
+        unless %w[status count md5].include?(configuration[:action])
           if Util.empty_filter?(options[:filter]) && !configuration[:yes]
             handle_message(:print, 3)
 
             STDOUT.flush
-            exit(1) unless STDIN.gets.strip.match(/^(?:y|yes)$/i)
+            exit(1) unless STDIN.gets.strip =~ /^(?:y|yes)$/i
           end
         end
       end
@@ -79,40 +97,63 @@ END_OF_USAGE
       def main
         pkg = rpcclient("package")
         if configuration[:version].nil?
-          pkg_result = pkg.send(configuration[:action], :package => configuration[:package])
+          pkg_result = pkg.send(
+            configuration[:action],
+            :package => configuration[:package]
+          )
         else
-          pkg_result = pkg.send(configuration[:action], :package => configuration[:package], :version => configuration[:version])
+          pkg_result = pkg.send(
+            configuration[:action],
+            :package => configuration[:package],
+            :version => configuration[:version]
+          )
         end
 
-        if !pkg_result.empty?
-          sender_width = pkg_result.map{|s| s[:sender]}.map{|s| s.length}.max + 3
+        unless pkg_result.empty?
+          sender_width = pkg_result.map {|s| s[:sender]}.map(&:length).max + 3
           pattern = "%%%ds: %%s" % sender_width
 
           pkg_result.each do |result|
             if result[:statuscode] == 0
               if pkg.verbose
-                if ['count', 'md5'].include?(configuration[:action])
+                if %w[count md5].include?(configuration[:action])
                   puts(pattern % [result[:sender], result[:data][:output]])
-                elsif ['yum_checkupdates', 'apt_update', 'checkupdates', 'apt_checkupdates'].include?(configuration[:action])
-                  status = result[:data][:outdated_packages].map{ |package| "%s-%s" % [package[:package], package[:version]] }.join(' ')
+                elsif %w[
+                  yum_checkupdates
+                  apt_update
+                  checkupdates
+                  apt_checkupdates
+                ].include?(configuration[:action])
+                  status = result[:data][:outdated_packages].map do |package|
+                    "%s-%s" % [package[:package], package[:version]]
+                  end.join(" ")
                   puts(pattern % [result[:sender], status])
+                elsif 'search'.include?(configuration[:action])
+                  puts(pattern % [result[:sender], result[:data][:package_count]])
                 else
                   puts(pattern % [result[:sender], result[:data][:ensure]])
                 end
               else
-                if configuration[:action] == 'status'
-                  if result[:data][:ensure] == 'absent'
-                    status = 'absent'
+                if configuration[:action] == "status"
+                  if result[:data][:ensure] == "absent"
+                    status = "absent"
                   else
-                    status = "%s-%s.%s" % [result[:data][:name], result[:data][:ensure], result[:data][:arch]]
+                    status = '%s-%s.%s' % [result[:data][:name], result[:data][:ensure], result[:data][:arch]]
                   end
                   puts(pattern % [result[:sender], status])
                 else
-                  if ['count', 'md5'].include?(configuration[:action])
+                  if %w[count md5].include?(configuration[:action])
                     status = "%s" % [result[:data][:output]]
                     puts(pattern % [result[:sender], status])
-                  elsif ['yum_checkupdates', 'apt_update', 'checkupdates', 'apt_checkupdates'].include?(configuration[:action])
-                    status = result[:data][:outdated_packages].map{ |package| package[:package] }.join(' ')
+                  elsif %w[
+                    yum_checkupdates
+                    apt_update
+                    checkupdates
+                    apt_checkupdates
+                  ].include?(configuration[:action])
+                    status = result[:data][:outdated_packages].map do |package|
+                      package[:package]
+                    end.join(" ")
                     puts(pattern % [result[:sender], status])
                   end
                 end

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -36,7 +36,7 @@ module MCollective
 
           expect{
             @app.post_option_parser({})
-          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates'
+          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, search, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates'
         end
 
         it 'should parse "action" "package" correctly' do

--- a/spec/util/package/base_spec.rb
+++ b/spec/util/package/base_spec.rb
@@ -54,6 +54,14 @@ module MCollective
             }.to raise_error 'error. MCollective::Util::Package::Base does not implement #status'
           end
         end
+
+        describe 'search' do
+          it 'should raise an error if called' do
+            expect{
+              base.search
+            }.to raise_error 'error. MCollective::Util::Package::Base does not implement #search'
+          end
+        end
       end
     end
   end

--- a/spec/util/package/packagehelpers_spec.rb
+++ b/spec/util/package/packagehelpers_spec.rb
@@ -157,21 +157,21 @@ module MCollective
 
         describe "rpm_count" do
           it 'should raise if rpm cannot be found on the system' do
-            File.expects(:exists?).with('/usr/bin/rpm').returns(false)
+            File.expects(:exists?).with('/bin/rpm').returns(false)
 
             expect{
               PackageHelpers.rpm_count
-            }.to raise_error 'Cannot find rpm at /usr/bin/rpm'
+            }.to raise_error 'Cannot find rpm at /bin/rpm'
           end
 
           it 'should raise if the rpm command failed' do
-            File.expects(:exists?).with('/usr/bin/rpm').returns(true)
+            File.expects(:exists?).with('/bin/rpm').returns(true)
             shell = mock
             status = mock
             shell.stubs(:runcommand)
             shell.stubs(:status).returns(status)
             status.stubs(:exitstatus).returns(-1)
-            Shell.expects(:new).with('/usr/bin/rpm -qa', :stdout => "").returns(shell)
+            Shell.expects(:new).with('/bin/rpm -qa', :stdout => "").returns(shell)
 
             expect{
               PackageHelpers.rpm_count
@@ -184,10 +184,10 @@ module MCollective
                       package2 2.2.2.el7.noarch
                       package3 3.3.3.el7.x86_64"
 
-            File.expects(:exists?).with('/usr/bin/rpm').returns(true)
+            File.expects(:exists?).with('/bin/rpm').returns(true)
             shell = mock
             status = mock
-            Shell.stubs(:new).with('/usr/bin/rpm -qa', :stdout => output).returns(shell)
+            Shell.stubs(:new).with('/bin/rpm -qa', :stdout => output).returns(shell)
             shell.stubs(:runcommand)
             shell.stubs(:stdout).returns(output)
             shell.expects(:status).returns(status)
@@ -200,21 +200,21 @@ module MCollective
 
         describe "rpm_md5" do
           it 'should raise if rpm cannot be found on the system' do
-            File.expects(:exists?).with('/usr/bin/rpm').returns(false)
+            File.expects(:exists?).with('/bin/rpm').returns(false)
 
             expect{
               PackageHelpers.rpm_md5
-            }.to raise_error 'Cannot find rpm at /usr/bin/rpm'
+            }.to raise_error 'Cannot find rpm at /bin/rpm'
           end
 
           it 'should raise if the rpm command failed' do
-            File.expects(:exists?).with('/usr/bin/rpm').returns(true)
+            File.expects(:exists?).with('/bin/rpm').returns(true)
             shell = mock
             status = mock
             shell.stubs(:runcommand)
             shell.stubs(:status).returns(status)
             status.stubs(:exitstatus).returns(-1)
-            Shell.expects(:new).with('/usr/bin/rpm -qa', :stdout => "").returns(shell)
+            Shell.expects(:new).with('/bin/rpm -qa', :stdout => "").returns(shell)
 
             expect{
               PackageHelpers.rpm_md5
@@ -227,10 +227,10 @@ module MCollective
                       package2 2.2.2.el7.noarch
                       package3 3.3.3.el7.x86_64"
 
-            File.expects(:exists?).with('/usr/bin/rpm').returns(true)
+            File.expects(:exists?).with('/bin/rpm').returns(true)
             shell = mock
             status = mock
-            Shell.stubs(:new).with('/usr/bin/rpm -qa', :stdout => output).returns(shell)
+            Shell.stubs(:new).with('/bin/rpm -qa', :stdout => output).returns(shell)
             shell.stubs(:runcommand)
             shell.stubs(:stdout).returns(output)
             shell.expects(:status).returns(status)

--- a/spec/util/package/yumpackage_spec.rb
+++ b/spec/util/package/yumpackage_spec.rb
@@ -40,6 +40,14 @@ module MCollective
           end
         end
 
+        describe "#search" do
+          it "should delegate to call_action" do
+            package.expects(:call_action).with(:search).returns("search output")
+
+            package.search.should == "search output"
+          end
+        end
+
         describe '#call_action' do
           let(:status)  { mock('status') }
           let(:command) do

--- a/util/package/base.rb
+++ b/util/package/base.rb
@@ -125,7 +125,7 @@ module MCollective
         # Providers extending the Base class should implement the status
         # method which is expected to return the status of a pacakge as
         # a hash containing the outputs described in the Status action of
-        # the packa DDL.
+        # the package DDL.
         #
         # Example:
         #   return {:arch => 'x86',
@@ -136,6 +136,28 @@ module MCollective
         #           :release => '1'}
         def status
           raise "error. %s does not implement #status" % self.class
+        end
+
+        # Providers extending the Base class should implement the search
+        # method which is expected to return either the status of a package
+        # being available for install/update to the system, or that the package
+        # is not available at all, as a hash containing the outputs described in
+        # the Search action of the package DDL.
+        #
+        # Example:
+        #    return [{
+        #     :name => 'kittens'
+        #     :arch => 'x86',
+        #     :ensure => 'xx-xx-xx',
+        #     :epoch => '123456',
+        #     :version => 'xx-xx-xx',
+        #     :provider => 'yum',
+        #     :release => '1'
+        #    },
+        #    ...
+        # ]
+        def search
+          raise "error. %s does not implement #search" % self.class
         end
       end
     end

--- a/util/package/packagehelpers.rb
+++ b/util/package/packagehelpers.rb
@@ -17,10 +17,10 @@ module MCollective
         end
 
         def self.rpm_count(output = "")
-          raise "Cannot find rpm at /usr/bin/rpm" unless File.exists?("/usr/bin/rpm")
+          raise "Cannot find rpm at /bin/rpm" unless File.exists?("/bin/rpm")
           result = {:exitcode => nil,
                     :output => ""}
-          cmd = Shell.new("/usr/bin/rpm -qa", :stdout => output)
+          cmd = Shell.new("/bin/rpm -qa", :stdout => output)
           cmd.runcommand
           result[:exitcode] = cmd.status.exitstatus
           result[:output] = output.split("\n").select{ |line| line != "" }.size.to_s
@@ -55,10 +55,10 @@ module MCollective
 
 
         def self.rpm_md5(output = "")
-          raise "Cannot find rpm at /usr/bin/rpm" unless File.exists?("/usr/bin/rpm")
+          raise "Cannot find rpm at /bin/rpm" unless File.exists?("/bin/rpm")
           result = {:exitcode => nil,
                     :output => ""}
-          cmd = Shell.new("/usr/bin/rpm -qa", :stdout => output)
+          cmd = Shell.new("/bin/rpm -qa", :stdout => output)
           cmd.runcommand
           result[:exitcode] = cmd.status.exitstatus
           result[:output] = Digest::MD5.new.hexdigest(output)

--- a/util/package/yumHelper.py
+++ b/util/package/yumHelper.py
@@ -4,7 +4,7 @@ import sys
 import json
 from yum.rpmtrans import NoOutputCallBack
 import logging
-from optparse import OptionParser
+from optparse import OptionParser, OptionGroup
 
 class YumHelper():
     def __init__(self):
@@ -21,32 +21,32 @@ class YumHelper():
     def _build_dict(self, po):
         pkg_list = []
         for p in po:
-            p_dict = { 'status': {
-                         'name': p.name,
-                         'version': p.version,
-                         'release': p.release,
-                         'epoch': p.epoch,
-                         'arch': p.arch,
-                         'provider': 'yum',
-                         'ensure': '%s-%s' % (p.version, p.release)
-                       }
-                     }
-            pkg_list.append(p_dict)
+            pkg_list.append(
+                {
+                    'name': p.name,
+                    'version': p.version,
+                    'release': p.release,
+                    'epoch': p.epoch,
+                    'arch': p.arch,
+                    'provider': 'yum',
+                    'ensure': '%s-%s' % (p.version, p.release)
+                }
+            )
         return pkg_list
 
     def install(self, package):
         try:
-            p = self.yb.install(name=package)
+            p = self.yb.install(pattern=package)
             self.yb.buildTransaction()
             self.yb.processTransaction(rpmDisplay=NoOutputCallBack())
             if p:
-                p_dict = self._build_dict(p)[0]
+                p_dict = {'status': self._build_dict(p)[0]}
             else:
                 p_dict = { 'msg': 'already installed and latest version',
                            'status': {} }
-        except yum.Errors.InstallError, e:
+        except yum.Errors.InstallError as e:
             p_dict = {'msg': str(e),
-                      'status': 'Failed' }
+                      'status': [] }
         finally:
             self.yb.closeRpmDB()
         return json.dumps(p_dict, sort_keys=True)
@@ -57,13 +57,13 @@ class YumHelper():
             self.yb.buildTransaction()
             self.yb.processTransaction(rpmDisplay=NoOutputCallBack())
             if p:
-                p_dict = self._build_dict(p)[0]
+                p_dict = {'status': self._build_dict(p)[0]}
             else:
                 p_dict = { 'msg': 'Package not installed',
                            'status': {} }
-        except yum.Errors.InstallError, e:
+        except yum.Errors.InstallError as e:
             p_dict = {'msg': str(e),
-                      'status': 'Failed' }
+                      'status': [] }
         finally:
             self.yb.closeRpmDB()
         return json.dumps(p_dict, sort_keys=True)
@@ -78,12 +78,10 @@ class YumHelper():
             self.yb.buildTransaction()
             self.yb.processTransaction(rpmDisplay=NoOutputCallBack())
             if len(p) > 1:
-                p_dict = { 'status': 'Everything updated' }
-            elif len(p) == 1:
-                p_dict = self._build_dict(p)[0]
+                p_dict = { 'status': self._build_dict(p)[0] }
             else:
                 p_dict = { 'status': 'Everything is up to date' }
-        except yum.Errors.InstallError, e:
+        except yum.Errors.InstallError as e:
             p_dict = {'msg': str(e),
                       'status': 'Failed' }
         finally:
@@ -94,14 +92,28 @@ class YumHelper():
         try:
             p = self.yb.rpmdb.searchNevra(name=package)
             if p:
-                p_dict = self._build_dict(p)[0]['status']
+                p_dict = self._build_dict(p)[0]
             else:
                 p_dict = { 'status': 'Not installed' }
-        except yum.Errors.InstallError, e:
+        except yum.Errors.InstallError as e:
             p_dict = {'msg': str(e),
                       'status': 'Failed' }
         finally:
             self.yb.closeRpmDB()
+        return json.dumps(p_dict, sort_keys=True)
+
+    def search(self, package):
+        try:
+            packages = self.yb.pkgSack.matchPackageNames([package])
+            if packages[0] or packages[1]:
+                p_dict = {}
+                p_dict['status'] = { "available_packages" : self._build_dict(packages[0] + packages[1]) }
+                p_dict['status']["package_count"] = "%s packages found" % (len(p_dict['status']['available_packages'])) 
+            else:
+                p_dict = { 'msg': 'Package not found', 'status': {'available_packages': []} }
+        finally:
+            self.yb.closeRpmDB()
+
         return json.dumps(p_dict, sort_keys=True)
 
 def parse_options():
@@ -115,10 +127,13 @@ def parse_options():
                      help="Status of package")
     parser.add_option('-u', '--update', type="string", dest="update",
                      help="Update package, \"*\" for all ")
+    parser.add_option('--search', type="string", dest="search",
+                          help="Search for package name, glob, or pkgspec (epoch:name-ver-rel.arch)")
     options, args = parser.parse_args()
 
     if (not options.install and not options.remove
-        and not options.update and not options.status):
+        and not options.update and not options.status
+        and not options.search):
         parser.error("use --help for help ")
 
     return options
@@ -127,12 +142,14 @@ def main():
     options = parse_options()
     y = YumHelper()
     if options.install:
-        print y.install(options.install)
+        print(y.install(options.install))
     if options.remove:
-        print y.remove(options.remove)
+        print(y.remove(options.remove))
     if options.update:
-        print y.update(options.update)
+        print(y.update(options.update))
     if options.status:
-        print y.status(options.status)
+        print(y.status(options.status))
+    if options.search:
+        print(y.search(options.search))
 if __name__ == '__main__':
     main()

--- a/util/package/yumpackage.rb
+++ b/util/package/yumpackage.rb
@@ -1,29 +1,33 @@
 module MCollective
   module Util
     module Package
-      class YumPackage<Base
+      class YumPackage < Base
         def install
-          return call_action(:install)
+          call_action(:install)
         end
 
         def update
-          return call_action(:update)
+          call_action(:update)
         end
 
         def uninstall
-          return call_action(:remove)
+          call_action(:remove)
         end
 
         # Status returns a hash of package properties
         def status
-          return call_action(:status)
+          call_action(:status)
+        end
+
+        def search
+          call_action(:search)
         end
 
         # Calls and cleans up the yum provider
         def call_action(action)
-          require 'json'
+          require "json"
           yumhelper = File::join(File::dirname(__FILE__), "yumHelper.py")
-          raise 'Cannot find yumHelper.py' unless File.exists?(yumhelper)
+          raise "Cannot find yumHelper.py" unless File.exists?(yumhelper)
           result = {:exitcode => nil,
                     :output => ""}
 
@@ -39,7 +43,7 @@ module MCollective
           if r[:status].is_a?(Hash)
             r[:status] = Hash[r[:status].map{|(k,v)| [k.to_sym,v]}]
           end
-          return r
+          r
         end
       end
     end


### PR DESCRIPTION
Adds a 'search' verb that allows for querying a package provider for a package's existence.  Currently only works with the yum provider.

Add rubocop configuration source from upstream.