### PR TITLE
(misc) Enhance the output of the package application

### DIFF
--- a/application/package.rb
+++ b/application/package.rb
@@ -138,7 +138,8 @@ USAGE
                   if result[:data][:ensure] == "absent"
                     status = "absent"
                   else
-                    status = '%s-%s.%s' % [result[:data][:name], result[:data][:ensure], result[:data][:arch]]
+                    status = '%s-%s' % [result[:data][:name], result[:data][:ensure]]
+                    status += ".#{result[:data][:arch]}" if result[:data][:arch]
                   end
                   puts(pattern % [result[:sender], status])
                 else

--- a/application/package.rb
+++ b/application/package.rb
@@ -135,8 +135,9 @@ USAGE
                 end
               else
                 if configuration[:action] == "status"
-                  if result[:data][:ensure] == "absent"
-                    status = "absent"
+                  case result[:data][:ensure]
+                  when "absent", "purged"
+                    status = result[:data][:ensure]
                   else
                     status = '%s-%s' % [result[:data][:name], result[:data][:ensure]]
                     status += ".#{result[:data][:arch]}" if result[:data][:arch]


### PR DESCRIPTION
The application output is somewhat inconsistent on my Debian nodes, this PR attemps to improve the situation by removing a redundant dot at the end of the package names (used for separating package name and architecture, but architetcure is not provided on Debian hosts) and purged packages where not handled the same was as absent packages.

Previous output:
```
% mco package status docker-ce    
    
 * [ ============================================================> ] 16 / 16    
    
        xxxxxxxxxxxxxxxxxxxxx: docker-ce-3:19.03.5-3.el7.x86_64    
   xxxxxxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial.    
       xxxxxxxxxxxxxxxxxxxxxx: absent    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
        xxxxxxxxxxxxxxxxxxxxx: docker-ce-purged.    
    
Summary of Arch:    
    
   x86_64 = 1    
    
Summary of Ensure:    
    
                        purged = 10    
   5:19.03.4~3-0~ubuntu-xenial = 4    
                        absent = 1    
               3:19.03.5-3.el7 = 1    
    
    
Finished processing 16 / 16 hosts in 3073.53 ms    
```

With these changes:

```
% mco package status docker-ce  

 * [ ============================================================> ] 16 / 16

        xxxxxxxxxxxxxxxxxxxxx: docker-ce-3:19.03.5-3.el7.x86_64
   xxxxxxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial
       xxxxxxxxxxxxxxxxxxxxxx: docker-ce-5:19.03.4~3-0~ubuntu-xenial
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: absent
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: purged
       xxxxxxxxxxxxxxxxxxxxxx: purged
        xxxxxxxxxxxxxxxxxxxxx: purged

Summary of Arch:

   x86_64 = 1

Summary of Ensure:

                        purged = 10
   5:19.03.4~3-0~ubuntu-xenial = 4
                        absent = 1
               3:19.03.5-3.el7 = 1


Finished processing 16 / 16 hosts in 2971.63 ms
```