### PR TITLE
Add FreeBSD pkg support

### DIFF
--- a/agent/package.ddl
+++ b/agent/package.ddl
@@ -248,3 +248,13 @@ action "checkupdates", :description => "Check for updates" do
            :description => "The exitcode from the package manager command",
            :display_as => "Exit Code"
 end
+
+action "refresh", :description => "Update the available packages cache" do
+    output :output,
+           :description => "Output from the package manager",
+           :display_as  => "Output"
+
+    output :exitcode,
+           :description => "The exitcode from the package manager",
+           :display_as => "Exit Code"
+end

--- a/agent/package.rb
+++ b/agent/package.rb
@@ -45,6 +45,12 @@ module MCollective
         reply[:output] = result[:output]
       end
 
+      action "refresh" do
+        result = package_helper.refresh
+        reply[:exitcode] = result[:exitcode]
+        reply[:output] = result[:output]
+      end
+
       action "apt_update" do
         result = package_helper.apt_update
         reply[:exitcode] = result[:exitcode]

--- a/application/package.rb
+++ b/application/package.rb
@@ -18,6 +18,7 @@ The ACTION can be one of the following:
     count            - determine number of packages installed
     md5              - determine md5 of package list
     search           - Determine if package is available to the system
+    refresh          - refresh the list of available packages
     yum_clean        - clean the yum cache
     yum_checkupdates - display available updates from yum
     apt_update       - update all available packages
@@ -55,6 +56,7 @@ USAGE
           apt_update
           checkupdates
           apt_checkupdates
+          refresh
         ]
         if (ARGV.size < 2) && !valid_global_actions.include?(ARGV[0])
           handle_message(:raise, 1)
@@ -94,6 +96,11 @@ USAGE
         end
       end
 
+      def format_output(pattern, sender_width, result)
+        output = result[:data][:output].gsub("\n", "\n" + " " * (sender_width + 2))
+        pattern % [result[:sender], output]
+      end
+
       def main
         pkg = rpcclient("package")
         if configuration[:version].nil?
@@ -128,7 +135,9 @@ USAGE
                     "%s-%s" % [package[:package], package[:version]]
                   end.join(" ")
                   puts(pattern % [result[:sender], status])
-                elsif 'search'.include?(configuration[:action])
+                elsif %w[refresh].include?(configuration[:action])
+                  puts(format_output(pattern, sender_width, result))
+                elsif %w[search].include?(configuration[:action])
                   puts(pattern % [result[:sender], result[:data][:package_count]])
                 else
                   puts(pattern % [result[:sender], result[:data][:ensure]])

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -36,7 +36,7 @@ module MCollective
 
           expect{
             @app.post_option_parser({})
-          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, search, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates'
+          }.to raise_error 'Action has to be one of install, uninstall, purge, update, status, search, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates, refresh'
         end
 
         it 'should parse "action" "package" correctly' do

--- a/util/package/packagehelpers.rb
+++ b/util/package/packagehelpers.rb
@@ -11,6 +11,8 @@ module MCollective
             return rpm_count
           elsif manager == :apt
             return dpkg_count
+          elsif manager == :pkg
+            return pkg_count
           else
             raise 'Cannot find a compatible package system to count packages'
           end
@@ -42,12 +44,27 @@ module MCollective
           return result
         end
 
+        def self.pkg_count(output = "")
+          raise "Cannot find pkg at /usr/sbin/pkg" unless File.exists?("/usr/sbin/pkg")
+          result = {:exitcode => nil,
+                    :output => ""}
+          cmd = Shell.new("/usr/sbin/pkg query '%n'", :stdout => output)
+          cmd.runcommand
+          result[:exitcode] = cmd.status.exitstatus
+          result[:output] = output.chomp.split("\n").size.to_s
+
+          raise "pkg command failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
+          return result
+        end
+
         def self.md5
           manager = packagemanager
           if manager == :yum
             return rpm_md5
           elsif manager == :apt
             return dpkg_md5
+          elsif manager == :pkg
+            return pkg_md5
           else
             raise 'Cannot find a compatible package system to get a md5 of the package list'
           end
@@ -77,6 +94,19 @@ module MCollective
           result[:output] = Digest::MD5.new.hexdigest(output.split("\n").select{ |line| line[0..1] == "ii"}.join("\n"))
 
           raise "dpkg command failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
+          return result
+        end
+
+        def self.pkg_md5(output = "")
+          raise "Cannot find pkg at /usr/sbin/pkg" unless File.exists?("/usr/sbin/pkg")
+          result = {:exitcode => nil,
+                    :output => ""}
+          cmd = Shell.new("/usr/sbin/pkg query '%n'", :stdout => output)
+          cmd.runcommand
+          result[:exitcode] = cmd.status.exitstatus
+          result[:output] = Digest::MD5.new.hexdigest(output.chomp)
+
+          raise "pkg command failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
           return result
         end
 
@@ -113,6 +143,20 @@ module MCollective
           return apt_checkupdates
         end
 
+        def self.pkg_update
+          raise 'Cannot find pkg at /usr/sbin/pkg' unless File.exists?('/usr/sbin/pkg')
+          result = {:exitcode => nil,
+                    :output => ""}
+
+          cmd = Shell.new('/usr/sbin/pkg update', :stdout => result[:output])
+          cmd.runcommand
+          result[:exitcode] = cmd.status.exitstatus
+
+          raise "pkg update failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
+
+          return result
+        end
+
         def self.yum_update
           raise "Cannot find yum at /usr/bin/yum" unless File.exists?("/usr/bin/yum")
 
@@ -142,6 +186,8 @@ module MCollective
             return :apt
           elsif File.exists?('/usr/bin/zypper')
             return :zypper
+          elsif File.exists?('/usr/sbin/pkg')
+            return :pkg
           end
         end
 
@@ -153,6 +199,8 @@ module MCollective
             return apt_checkupdates
           elsif manager == :zypper
             return zypper_checkupdates
+          elsif manager == :pkg
+            return pkg_checkupdates
           else
             raise 'Cannot find a compatible package system to check updates'
           end
@@ -238,10 +286,59 @@ module MCollective
           result
         end
 
+        def self.pkg_checkupdates(query_output = "", rquery_output = "")
+          raise 'Cannot find pkg at /usr/sbin/pkg' unless File.exists?('/usr/sbin/pkg')
+
+          result = {:exitcode => nil,
+                    :output => "",
+                    :outdated_packages => [],
+                    :package_manager => 'pkg'}
+
+          cmd = Shell.new('/usr/sbin/pkg query --all "%n\\t%v\\t%R"', :stdout => query_output)
+          cmd.runcommand
+          result[:exitcode] = cmd.status.exitstatus
+          raise "pkg query failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
+
+          installed_packages = {}
+          query_output.chomp.split("\n").each do |line|
+            name, version, repository = line.split("\t")
+            installed_packages[name] = { :version => version, :repository => repository }
+          end
+
+          cmd = Shell.new('/usr/sbin/pkg rquery --all --no-repo-update "%n\\t%v\\t%R"', :stdout => rquery_output)
+          cmd.runcommand
+          result[:exitcode] = cmd.status.exitstatus
+          raise "pkg rquery failed, exit code was #{result[:exitcode]}" unless result[:exitcode] == 0
+
+          available_packages = {}
+          rquery_output.chomp.split("\n").each do |line|
+            name, version, repository = line.split("\t")
+            available_packages[name] = { :version => version, :repository => repository }
+          end
+
+          installed_packages.each do |name, info|
+            if available_packages[name] && available_packages[name] != info
+              result[:outdated_packages] << {:package => name,
+                                             :version => available_packages[name][:version],
+                                             :repo => available_packages[name][:repository]}
+            end
+          end
+
+          # Mimic the output from pkg version
+          result[:output] = result[:outdated_packages].map do |package|
+            installed = sprintf("%s-%s", package[:package], installed_packages[package[:package]][:version])
+            sprintf("%-34s <   needs updating (remote has %s)\n", installed, package[:version])
+          end.join
+
+          result
+        end
+
         def self.refresh
           manager = packagemanager
           if manager == :apt
             return apt_update
+          elsif manager == :pkg
+            return pkg_update
           elsif manager == :yum
             return yum_update
           elsif manager == :zypper


### PR DESCRIPTION
```sh-session
romain@zappy ~ $ mco package checkupdates -I `hostname -f`

 * [ ==========================================================> ] 1 / 1

   zappy.home.sigabrt.org: audacity c-ares check cups curl dav1d dbus devcpu-data e2fsprogs e2fsprogs-libblkid ffmpeg firefox glib gtk-update-icon-cache gtk3 harfbuzz harfbuzz-icu lcms2 libev mencoder mesa-dri mesa-libs meson mplayer mumble mutt nspr nss p5-CGI p5-MIME-Base32 pdfcrack pdftk pkg pkgconf py37-more-itertools rubygem-ast rubygem-aws-partitions rubygem-aws-sdk-core rubygem-aws-sdk-ec2 rubygem-aws-sigv4 rubygem-bolt rubygem-parallel rubygem-parser rubygem-r10k sudo youtube_dl


Finished processing 1 / 1 hosts in 9520.61 ms

romain@zappy ~ $ mco package count -I `hostname -f`

 * [ ==========================================================> ] 1 / 1

   zappy.home.sigabrt.org: 899

Summary of Count:

   899 = 1


Finished processing 1 / 1 hosts in 1141.52 ms

romain@marvin ~ $
```

Fixes #21 
Fixes #23