### PR TITLE
Update CI to use current Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
 name: Continuous Integration
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v2
+    with:
+      allowed_owner: 'choria-plugins'
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      username: ${{ secrets.PUPPET_FORGE_USERNAME }}
+      api_key: ${{ secrets.PUPPET_FORGE_API_KEY }}

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,13 +1,15 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
+/docs/
 /pkg/
+/Gemfile
 /Gemfile.lock
 /Gemfile.local
 /vendor/
 /.vendor/
-/spec/fixtures/manifests/
-/spec/fixtures/modules/
+/spec/
+/Rakefile
 /.vagrant/
 /.bundle/
 /.ruby-version
@@ -15,11 +17,23 @@
 /log/
 /.idea/
 /.dependencies/
+/.github/
 /.librarian/
 /Puppetfile.lock
+/Puppetfile
 *.iml
+/.editorconfig
+/.fixtures.yml
+/.gitignore
+/.msync.yml
+/.overcommit.yml
+/.pmtignore
+/.rspec
+/.rspec_parallel
+/.rubocop.yml
+/.sync.yml
 .*.sw?
 /.yardoc/
-/Guardfile
-bolt-debug.log
-.rerun.json
+/.yardopts
+/Dockerfile
+/HISTORY.md

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "json", "~> 1.8.3"
+  gem "json"
   gem "mcollective-test"
-  gem "mocha", "~> 0.10.0"
-  gem "rake", "~> 10.4"
-  gem "rspec", "~> 2.11.0"
+  gem "mocha"
+  gem "rake"
+  gem "rspec"
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,18 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
 specdir = File.join([File.dirname(__FILE__), "spec"])
 
 require "rake"
 begin
   require "rspec/core/rake_task"
   require "mcollective"
-rescue LoadError
-  # Ignore if bundled without tests
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+desc "Run rubycop style checks"
+task :rubocop do
+  sh("rubocop")
 end
 
 desc "Run agent and application tests"
@@ -19,11 +26,11 @@ task :test do
   sh "bundle exec rspec #{Dir.glob(test_pattern).sort.join(' ')}"
 end
 
-task :default => :test
+task :default => [:rubocop, :test]
 
 desc "Expands the action details section in a README.md file"
 task :readme_expand do
-  ddl_file = Dir.glob(File.join("agent/*.ddl")).first
+  ddl_file = Dir.glob("agent/*.ddl").first
 
   return unless ddl_file
 
@@ -31,7 +38,7 @@ task :readme_expand do
   ddl.instance_eval(File.read(ddl_file))
 
   lines = File.readlines("puppet/README.md").map do |line|
-    if /^<!--- actions -->/.match?(line)
+    if line.match?(/^<!--- actions -->/)
       [
         "## Actions\n\n",
         "This agent provides the following actions, for details about each please run `mco plugin doc agent/%s`\n\n" % ddl.meta[:name]
@@ -76,5 +83,5 @@ end
 
 desc "Builds the module found in the current directory, run build_prep first"
 task :build do
-  sh "/opt/puppetlabs/puppet/bin/mco plugin package --vendor choria"
+  sh "/opt/puppetlabs/puppet/bin/mco plugin package --format aiomodulepackage --vendor choria"
 end

--- a/data/package_data.rb
+++ b/data/package_data.rb
@@ -6,7 +6,7 @@ module MCollective
       query do |package|
         val = {}
         Agent::Package.do_pkg_action(package, :status, val)
-        result[:status] = val[:ensure]
+        result[:status] = val[:ensure] if val[:ensure]
         # If the package is either 'absent' or 'purged' report it as not installed
         result[:installed] = !["absent", "purged"].include?(val[:ensure])
       rescue => e

--- a/spec/agent/package_agent_spec.rb
+++ b/spec/agent/package_agent_spec.rb
@@ -254,9 +254,9 @@ module MCollective
 
         it "should log and raise if the provider cannot be loaded" do
           PluginManager.stubs(:loadclass).raises("error")
-          expect {
+          lambda {
             described_class.load_provider_class("rspec")
-          }.to raise_error "Cannot load package provider class 'RspecPackage': error"
+          }.should raise_error "Cannot load package provider class 'RspecPackage': error"
         end
       end
 
@@ -309,9 +309,9 @@ module MCollective
         it "should raise an error if the :msg key is set" do
           reply = {}
           provider.expects(:send, "rspec").returns({:status => {:k1 => "v1", :k2 => "v2"}, :msg => "error"})
-          expect {
+          lambda {
             described_class.do_pkg_action("rspec", "rspec_action", reply)
-          }.to raise_error "error"
+          }.should raise_error "error"
         end
       end
 

--- a/spec/application/package_application_spec.rb
+++ b/spec/application/package_application_spec.rb
@@ -20,23 +20,23 @@ module MCollective
       describe "#post_option_parser" do
         it "should fail if both an action and package are not supplied" do
           ARGV << "rspec"
-          expect {
+          lambda {
             @app.post_option_parser({})
-          }.to raise_error "Please specify package name and action"
+          }.should raise_error "Please specify package name and action"
 
           ARGV.shift
-          expect {
+          lambda {
             @app.post_option_parser({})
-          }.to raise_error "Please specify package name and action"
+          }.should raise_error "Please specify package name and action"
         end
 
         it "should fail on an unknown action" do
           ARGV << "rspec"
           ARGV << "rspec"
 
-          expect {
+          lambda {
             @app.post_option_parser({})
-          }.to raise_error "Action has to be one of install, uninstall, purge, update, status, search, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates, refresh"
+          }.should raise_error "Action has to be one of install, uninstall, purge, update, status, search, count, md5, yum_clean, yum_checkupdates, apt_update, checkupdates, apt_checkupdates, refresh"
         end
 
         it 'should parse "action" "package" correctly' do

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,1 +1,0 @@
---colour --backtrace

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require "tempfile"
 RSpec.configure do |config|
   config.mock_with :mocha
   config.include(MCollective::Test::Matchers)
+  config.raise_errors_for_deprecations!
+  config.expect_with(:rspec) { |c| c.syntax = :should }
 
   config.before :each do
     MCollective::PluginManager.clear

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
-$: << File.join([File.dirname(__FILE__), "lib"])
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
 require "rubygems"
 require "rspec"
@@ -17,3 +18,5 @@ RSpec.configure do |config|
     MCollective::PluginManager.clear
   end
 end
+
+Dir["./spec/support/spec/**/*.rb"].sort.each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require "rubygems"
 require "rspec"
 require "mcollective"
 require "mcollective/test"
-require "rspec/mocks"
 require "mocha"
 require "tempfile"
 

--- a/spec/util/package/base_spec.rb
+++ b/spec/util/package/base_spec.rb
@@ -18,49 +18,49 @@ module MCollective
 
         describe "install" do
           it "should raise an error if called" do
-            expect {
+            lambda {
               base.install
-            }.to raise_error "error. MCollective::Util::Package::Base does not implement #install"
+            }.should raise_error "error. MCollective::Util::Package::Base does not implement #install"
           end
         end
 
         describe "uninstall" do
           it "should raise an error if called" do
-            expect {
+            lambda {
               base.uninstall
-            }.to raise_error "error. MCollective::Util::Package::Base does not implement #uninstall"
+            }.should raise_error "error. MCollective::Util::Package::Base does not implement #uninstall"
           end
         end
 
         describe "purge" do
           it "should raise an error if called" do
-            expect {
+            lambda {
               base.purge
-            }.to raise_error "error. MCollective::Util::Package::Base does not implement #purge"
+            }.should raise_error "error. MCollective::Util::Package::Base does not implement #purge"
           end
         end
 
         describe "update" do
           it "should raise an error if called" do
-            expect {
+            lambda {
               base.update
-            }.to raise_error "error. MCollective::Util::Package::Base does not implement #update"
+            }.should raise_error "error. MCollective::Util::Package::Base does not implement #update"
           end
         end
 
         describe "status" do
           it "should raise an error if called" do
-            expect {
+            lambda {
               base.status
-            }.to raise_error "error. MCollective::Util::Package::Base does not implement #status"
+            }.should raise_error "error. MCollective::Util::Package::Base does not implement #status"
           end
         end
 
         describe "search" do
           it "should raise an error if called" do
-            expect {
+            lambda {
               base.search
-            }.to raise_error "error. MCollective::Util::Package::Base does not implement #search"
+            }.should raise_error "error. MCollective::Util::Package::Base does not implement #search"
           end
         end
       end

--- a/spec/util/package/packagehelpers_spec.rb
+++ b/spec/util/package/packagehelpers_spec.rb
@@ -10,16 +10,16 @@ module MCollective
         describe "#yum_clean" do
           it "raises if the yum binary cannot be found" do
             File.expects(:exist?).with("/usr/bin/yum").returns(false)
-            expect {
+            lambda {
               described_class.yum_clean("all")
-            }.to raise_error("Cannot find yum at /usr/bin/yum")
+            }.should raise_error("Cannot find yum at /usr/bin/yum")
           end
 
           it "raises if an unsupported clean mode is supplied" do
             File.expects(:exist?).with("/usr/bin/yum").returns(true)
-            expect {
+            lambda {
               described_class.yum_clean("rspec")
-            }.to raise_error("Unsupported yum clean mode: rspec")
+            }.should raise_error("Unsupported yum clean mode: rspec")
           end
 
           it "raises if the yum command failed" do
@@ -31,9 +31,9 @@ module MCollective
             shell.stubs(:status).returns(status)
             status.stubs(:exitstatus).returns(-1)
 
-            expect {
+            lambda {
               described_class.yum_clean("all")
-            }.to raise_error("Yum clean failed, exit code was -1")
+            }.should raise_error("Yum clean failed, exit code was -1")
           end
 
           it "cleans with the correct clean mode" do
@@ -80,18 +80,18 @@ module MCollective
           it "fails if no compatible package manager is present on the system" do
             described_class.expects(:packagemanager).returns(nil)
 
-            expect {
+            lambda {
               described_class.refresh
-            }.to raise_error "Cannot find a compatible package system to update packages"
+            }.should raise_error "Cannot find a compatible package system to update packages"
           end
         end
 
         describe "#apt_update" do
           it "raises if the apt-get binary cannot be found" do
             File.expects(:exist?).with("/usr/bin/apt-get").returns(false)
-            expect {
+            lambda {
               described_class.apt_update
-            }.to raise_error("Cannot find apt-get at /usr/bin/apt-get")
+            }.should raise_error("Cannot find apt-get at /usr/bin/apt-get")
           end
 
           it "raises if the apt-get command failed" do
@@ -103,9 +103,9 @@ module MCollective
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/bin/apt-get update", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.apt_update
-            }.to raise_error "apt-get update failed, exit code was -1"
+            }.should raise_error "apt-get update failed, exit code was -1"
           end
 
           it "performs the update" do
@@ -127,9 +127,9 @@ module MCollective
         describe "#pkg_update" do
           it "raises if the pkg binary cannot be found" do
             File.expects(:exist?).with("/usr/sbin/pkg").returns(false)
-            expect {
+            lambda {
               described_class.pkg_update
-            }.to raise_error("Cannot find pkg at /usr/sbin/pkg")
+            }.should raise_error("Cannot find pkg at /usr/sbin/pkg")
           end
 
           it "raises if the pkg command failed" do
@@ -141,9 +141,9 @@ module MCollective
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/sbin/pkg update", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.pkg_update
-            }.to raise_error "pkg update failed, exit code was -1"
+            }.should raise_error "pkg update failed, exit code was -1"
           end
 
           it "performs the update" do
@@ -163,9 +163,9 @@ module MCollective
         describe "#yum_update" do
           it "raises if the yum binary cannot be found" do
             File.expects(:exist?).with("/usr/bin/yum").returns(false)
-            expect {
+            lambda {
               described_class.yum_update
-            }.to raise_error("Cannot find yum at /usr/bin/yum")
+            }.should raise_error("Cannot find yum at /usr/bin/yum")
           end
 
           it "performs the update" do
@@ -182,9 +182,9 @@ module MCollective
         describe "#zypper_update" do
           it "raises if the zypper binary cannot be found" do
             File.expects(:exist?).with("/usr/bin/zypper").returns(false)
-            expect {
+            lambda {
               described_class.zypper_update
-            }.to raise_error("Cannot find zypper at /usr/bin/zypper")
+            }.should raise_error("Cannot find zypper at /usr/bin/zypper")
           end
 
           it "raises if the zypper command failed" do
@@ -196,9 +196,9 @@ module MCollective
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/bin/zypper refresh", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.zypper_update
-            }.to raise_error "zypper refresh failed, exit code was -1"
+            }.should raise_error "zypper refresh failed, exit code was -1"
           end
 
           it "performs the update" do
@@ -257,9 +257,9 @@ module MCollective
           it "fails if no compatible package manager is present on the system" do
             described_class.expects(:packagemanager).returns(nil)
 
-            expect {
+            lambda {
               described_class.count
-            }.to raise_error "Cannot find a compatible package system to count packages"
+            }.should raise_error "Cannot find a compatible package system to count packages"
           end
         end
 
@@ -285,9 +285,9 @@ module MCollective
           it "fails if no compatible package manager is present on the system" do
             described_class.expects(:packagemanager).returns(nil)
 
-            expect {
+            lambda {
               described_class.md5
-            }.to raise_error "Cannot find a compatible package system to get a md5 of the package list"
+            }.should raise_error "Cannot find a compatible package system to get a md5 of the package list"
           end
         end
 
@@ -295,9 +295,9 @@ module MCollective
           it "raises if rpm cannot be found on the system" do
             File.expects(:exist?).with("/bin/rpm").returns(false)
 
-            expect {
+            lambda {
               described_class.rpm_count
-            }.to raise_error "Cannot find rpm at /bin/rpm"
+            }.should raise_error "Cannot find rpm at /bin/rpm"
           end
 
           it "raises if the rpm command failed" do
@@ -309,9 +309,9 @@ module MCollective
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/bin/rpm -qa", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.rpm_count
-            }.to raise_error "rpm command failed, exit code was -1"
+            }.should raise_error "rpm command failed, exit code was -1"
           end
 
           it "should return the count of packages" do
@@ -337,9 +337,9 @@ module MCollective
           it "raises if rpm cannot be found on the system" do
             File.expects(:exist?).with("/bin/rpm").returns(false)
 
-            expect {
+            lambda {
               described_class.rpm_md5
-            }.to raise_error "Cannot find rpm at /bin/rpm"
+            }.should raise_error "Cannot find rpm at /bin/rpm"
           end
 
           it "raises if the rpm command failed" do
@@ -351,9 +351,9 @@ module MCollective
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/bin/rpm -qa", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.rpm_md5
-            }.to raise_error "rpm command failed, exit code was -1"
+            }.should raise_error "rpm command failed, exit code was -1"
           end
 
           it "should return the md5 of packages" do
@@ -379,9 +379,9 @@ module MCollective
           it "raises if dpkg cannot be found on the system" do
             File.expects(:exist?).with("/usr/bin/dpkg").returns(false)
 
-            expect {
+            lambda {
               described_class.dpkg_count
-            }.to raise_error "Cannot find dpkg at /usr/bin/dpkg"
+            }.should raise_error "Cannot find dpkg at /usr/bin/dpkg"
           end
 
           it "raises if the dpkg command failed" do
@@ -393,9 +393,9 @@ module MCollective
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/bin/dpkg --list", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.dpkg_count
-            }.to raise_error "dpkg command failed, exit code was -1"
+            }.should raise_error "dpkg command failed, exit code was -1"
           end
 
           it "should return the count of packages" do
@@ -427,9 +427,9 @@ ii  account-plugin-aim                                    3.12.11-0ubuntu3      
           it "raises if dpkg cannot be found on the system" do
             File.expects(:exist?).with("/usr/bin/dpkg").returns(false)
 
-            expect {
+            lambda {
               described_class.dpkg_md5
-            }.to raise_error "Cannot find dpkg at /usr/bin/dpkg"
+            }.should raise_error "Cannot find dpkg at /usr/bin/dpkg"
           end
 
           it "raises if the dpkg command failed" do
@@ -441,9 +441,9 @@ ii  account-plugin-aim                                    3.12.11-0ubuntu3      
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/bin/dpkg --list", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.dpkg_md5
-            }.to raise_error "dpkg command failed, exit code was -1"
+            }.should raise_error "dpkg command failed, exit code was -1"
           end
 
           it "should return the md5 of packages" do
@@ -475,9 +475,9 @@ ii  account-plugin-aim                                    3.12.11-0ubuntu3      
           it "raises if pkg cannot be found on the system" do
             File.expects(:exist?).with("/usr/sbin/pkg").returns(false)
 
-            expect {
+            lambda {
               described_class.pkg_count
-            }.to raise_error "Cannot find pkg at /usr/sbin/pkg"
+            }.should raise_error "Cannot find pkg at /usr/sbin/pkg"
           end
 
           it "raises if the pkg command failed" do
@@ -489,9 +489,9 @@ ii  account-plugin-aim                                    3.12.11-0ubuntu3      
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/sbin/pkg query '%n'", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.pkg_count
-            }.to raise_error "pkg command failed, exit code was -1"
+            }.should raise_error "pkg command failed, exit code was -1"
           end
 
           it "should return the count of packages" do
@@ -517,9 +517,9 @@ rubygem-bolt"
           it "raises if pkg cannot be found on the system" do
             File.expects(:exist?).with("/usr/sbin/pkg").returns(false)
 
-            expect {
+            lambda {
               described_class.pkg_md5
-            }.to raise_error "Cannot find pkg at /usr/sbin/pkg"
+            }.should raise_error "Cannot find pkg at /usr/sbin/pkg"
           end
 
           it "raises if the pkg command failed" do
@@ -531,9 +531,9 @@ rubygem-bolt"
             status.stubs(:exitstatus).returns(-1)
             Shell.expects(:new).with("/usr/sbin/pkg query '%n'", :stdout => "").returns(shell)
 
-            expect {
+            lambda {
               described_class.pkg_md5
-            }.to raise_error "pkg command failed, exit code was -1"
+            }.should raise_error "pkg command failed, exit code was -1"
           end
 
           it "should return the md5 of packages" do
@@ -583,9 +583,9 @@ rubygem-bolt"
           it "fails if no compatible package manager is present on the system" do
             described_class.expects(:packagemanager).returns(nil)
 
-            expect {
+            lambda {
               described_class.checkupdates
-            }.to raise_error "Cannot find a compatible package system to check updates"
+            }.should raise_error "Cannot find a compatible package system to check updates"
           end
         end
 
@@ -593,9 +593,9 @@ rubygem-bolt"
           it "raises if yum cannot be found on the system" do
             File.expects(:exist?).with("/usr/bin/yum").returns(false)
 
-            expect {
+            lambda {
               described_class.yum_checkupdates
-            }.to raise_error "Cannot find yum at /usr/bin/yum"
+            }.should raise_error "Cannot find yum at /usr/bin/yum"
           end
 
           it "should return the list of outdated packages" do
@@ -623,9 +623,9 @@ rubygem-bolt"
           it "raises if zypper cannot be foud on the system" do
             File.expects(:exist?).with("/usr/bin/zypper").returns(false)
 
-            expect {
+            lambda {
               described_class.zypper_checkupdates
-            }.to raise_error "Cannot find zypper at /usr/bin/zypper"
+            }.should raise_error "Cannot find zypper at /usr/bin/zypper"
           end
 
           it "should return the list of outdated packages" do
@@ -655,9 +655,9 @@ rubygem-bolt"
           it "raises if apt cannot be found on the system" do
             File.expects(:exist?).with("/usr/bin/apt-get").returns(false)
 
-            expect {
+            lambda {
               described_class.apt_checkupdates
-            }.to raise_error "Cannot find apt-get at /usr/bin/apt-get"
+            }.should raise_error "Cannot find apt-get at /usr/bin/apt-get"
           end
 
           it "raises if the check-update command failed" do
@@ -669,9 +669,9 @@ rubygem-bolt"
             shell.expects(:status).returns(status)
             status.stubs(:exitstatus).returns(-1)
 
-            expect {
+            lambda {
               described_class.apt_checkupdates
-            }.to raise_error "Apt check-update failed, exit code was -1"
+            }.should raise_error "Apt check-update failed, exit code was -1"
           end
 
           it "should return the list of outdated packages" do
@@ -698,9 +698,9 @@ rubygem-bolt"
           it "raises if pkg cannot be found on the system" do
             File.expects(:exist?).with("/usr/sbin/pkg").returns(false)
 
-            expect {
+            lambda {
               described_class.pkg_checkupdates
-            }.to raise_error "Cannot find pkg at /usr/sbin/pkg"
+            }.should raise_error "Cannot find pkg at /usr/sbin/pkg"
           end
 
           it "raises if the query command failed" do
@@ -712,9 +712,9 @@ rubygem-bolt"
             shell.expects(:status).returns(status)
             status.stubs(:exitstatus).returns(-1)
 
-            expect {
+            lambda {
               described_class.pkg_checkupdates
-            }.to raise_error "pkg query failed, exit code was -1"
+            }.should raise_error "pkg query failed, exit code was -1"
           end
 
           it "raises if the rquery command failed" do
@@ -732,9 +732,9 @@ rubygem-bolt"
             rquery_shell.expects(:status).returns(rquery_status)
             rquery_status.stubs(:exitstatus).returns(-1)
 
-            expect {
+            lambda {
               described_class.pkg_checkupdates
-            }.to raise_error "pkg rquery failed, exit code was -1"
+            }.should raise_error "pkg rquery failed, exit code was -1"
           end
 
           it "should return the list of outdated packages" do

--- a/spec/util/package/puppetpackage_spec.rb
+++ b/spec/util/package/puppetpackage_spec.rb
@@ -159,12 +159,12 @@ module MCollective
         describe "#absent?" do
           it "should return true if the package is absent" do
             provider.stubs(:properties).returns(:ensure => :absent)
-            package.send(:absent?).should be_true
+            package.send(:absent?).should be_truthy
           end
 
           it "should return false if the package is present" do
             provider.stubs(:properties).returns(:ensure => "xx-xx-xx")
-            package.send(:absent?).should be_false
+            package.send(:absent?).should be_falsey
           end
         end
 

--- a/spec/validator/package_name_validator_spec.rb
+++ b/spec/validator/package_name_validator_spec.rb
@@ -8,30 +8,30 @@ module MCollective
     describe Package_nameValidator do
       describe "#validate" do
         it "should validate a valid package name without errors" do
-          expect {
+          lambda {
             described_class.validate("rspec")
-          }.not_to raise_error
+          }.should_not raise_error
 
-          expect {
+          lambda {
             described_class.validate("rspec1")
-          }.not_to raise_error
+          }.should_not raise_error
 
-          expect {
+          lambda {
             described_class.validate("rspec-package")
-          }.not_to raise_error
+          }.should_not raise_error
 
-          expect {
+          lambda {
             described_class.validate("rspec-package-1")
-          }.not_to raise_error
+          }.should_not raise_error
 
-          expect {
+          lambda {
             described_class.validate("rspec.package")
-          }.not_to raise_error
+          }.should_not raise_error
         end
         it "should fail on a invalid package name" do
-          expect {
+          lambda {
             described_class.validate("rspec!")
-          }.to raise_error
+          }.should raise_error(RuntimeError, "rspec! is not a valid package name")
         end
       end
     end

--- a/util/package/puppetpackage.rb
+++ b/util/package/puppetpackage.rb
@@ -46,7 +46,7 @@ module MCollective
           require "puppet"
           @provider ||= Puppet::Type.type(:package).new({:name => @package}.merge(@options)).provider
 
-          if @provider.class.to_s == "Puppet::Type::Package::ProviderWindows"
+          if @provider.class.to_s == "Puppet::Type::Package::ProviderWindows" # rubocop:disable Style/ClassEqualityComparison
             # the windows provider cannot uninstall unless you got the object
             # via instances, as uninstall is implemented in terms of
             # provider.package


### PR DESCRIPTION
The dependencies used by the project are not compatible with the current versions of Ruby.

This PR remove the constraints on the gems needed to run the test suite and adjust the code so that the test suite can run with modern Ruby.

~This require a recent version of `mcollective-test` not yet released, so CI failures are expected at the moment.~

